### PR TITLE
Fix phrasing on contributions section of `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ variables.
 Pull requests and bug reports are welcome. For larger changes please create an
 issue first to discuss your proposed changes and possible implications.
 
-More more details please see the [CONTRIBUTING.md](./CONTRIBUTING.md)
+For more details please see the [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
## Description

Fixes phrasing on `README` Contributing section: `More more details` -> `For more details`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)