### PR TITLE
Add debug mode for otel zero code instrumentation

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,12 +21,19 @@ INTEGRATION_TEST_URL=${INTEGRATION_TEST_URL:-"https://github.com/cisco-open/"}
 
 FULL_IMAGE_NAME=bats/bats:1.11.0
 
-# Check if we are doing a quick check, if so we will skip the integration tests.
+DISABLE_DOTNET=""
+
 for arg in "$@"; do
+	# Check if we are doing a quick check, if so we will skip the integration tests.
 	if [ "$arg" = "-q" ] || [ "$arg" = "--quick" ]; then
 		echo "No integration tests will be run"
 		WITH_INTEGRATION=0
-		break # Exit the loop if -q or --quick is found
+	fi
+
+	# Check if we are disabling dotnet integration tests.
+	if [ "$arg" = "-n" ] || [ "$arg" = "--disable-dotnet" ]; then
+		echo "Disabling dotnet integration tests"
+		DISABLE_DOTNET=(--filter-tags '!integration:dotnet')
 	fi
 done
 
@@ -43,4 +50,4 @@ if [ ${WITH_INTEGRATION} -eq 1 ]; then
 	${DOCKER_COMMAND} build -t "$FULL_IMAGE_NAME" .
 fi
 
-${DOCKER_COMMAND} run -it -e WITH_INTEGRATION="${WITH_INTEGRATION}" -e INTEGRATION_TEST_URL="${INTEGRATION_TEST_URL}" -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}:/code" "${FULL_IMAGE_NAME}" --filter-tags '!integration:dotnet' test
+${DOCKER_COMMAND} run -it -e WITH_INTEGRATION="${WITH_INTEGRATION}" -e INTEGRATION_TEST_URL="${INTEGRATION_TEST_URL}" -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}:/code" "${FULL_IMAGE_NAME}" "${DISABLE_DOTNET[@]}" test 

--- a/test.sh
+++ b/test.sh
@@ -43,4 +43,4 @@ if [ ${WITH_INTEGRATION} -eq 1 ]; then
 	${DOCKER_COMMAND} build -t "$FULL_IMAGE_NAME" .
 fi
 
-${DOCKER_COMMAND} run -it -e WITH_INTEGRATION="${WITH_INTEGRATION}" -e INTEGRATION_TEST_URL="${INTEGRATION_TEST_URL}" -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}:/code" "${FULL_IMAGE_NAME}" -x --verbose-run test
+${DOCKER_COMMAND} run -it -e WITH_INTEGRATION="${WITH_INTEGRATION}" -e INTEGRATION_TEST_URL="${INTEGRATION_TEST_URL}" -e BATS_LIB_PATH=/usr/lib/bats -v "${PWD}:/code" "${FULL_IMAGE_NAME}" --filter-tags '!integration:dotnet' test

--- a/test/2-integration.bats
+++ b/test/2-integration.bats
@@ -50,10 +50,8 @@ teardown() {
 @test "can otelify nodejs applications" {    
     run otelify.sh -- node "${APP_DIR}/app.js"
     assert_output --partial 'traceId: '
-}
 
-#bats test_tags=integration:nodejs-debug, nodejs, debug
-@test "can otelify nodejs applications with debug mode enabled" {    
+    # Test with debug flag
     run otelify.sh -D -- node "${APP_DIR}/app.js"
     assert_output --partial '@opentelemetry/api: Registered a global for diag'
 }
@@ -67,10 +65,18 @@ teardown() {
     cd "${OLD_PWD}"
     run otelify.sh -d -- java -jar "${APP_DIR}/app.jar"
     assert_output --partial 'io.opentelemetry.exporter.logging.LoggingSpanExporter'
+
+    # Test with debug flag
+    run otelify.sh -d -D -- java -jar "${APP_DIR}/app.jar"
+    assert_output --partial '[main] DEBUG io.opentelemetry.javaagent.'
 }
 
 #bats test_tags=integration:dotnet, dotnet
 @test "can otelify dotnet applications" {
     run otelify.sh -d --  dotnet run --project "${APP_DIR}"
     assert_output --partial 'Activity.TraceId:'
+
+    # Test with debug flag
+    # run otelify.sh -D -d --  dotnet run --project "${APP_DIR}"
+    # assert_output --partial 'to be done'
 }

--- a/test/2-integration.bats
+++ b/test/2-integration.bats
@@ -52,6 +52,12 @@ teardown() {
     assert_output --partial 'traceId: '
 }
 
+#bats test_tags=integration:nodejs-debug, nodejs, debug
+@test "can otelify nodejs applications with debug mode enabled" {    
+    run otelify.sh -D -- node "${APP_DIR}/app.js"
+    assert_output --partial '@opentelemetry/api: Registered a global for diag'
+}
+
 #bats test_tags=integration:java, java
 @test "can otelify java applications" {
     OLD_PWD=${PWD}


### PR DESCRIPTION
## Description

Adds an additional flag (`-D`), that will enable debug logging for the used zero code instrumentation.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)